### PR TITLE
Update SimpleRouletteWheelSelector.java

### DIFF
--- a/src/santa/simulator/selectors/SimpleRouletteWheelSelector.java
+++ b/src/santa/simulator/selectors/SimpleRouletteWheelSelector.java
@@ -41,7 +41,9 @@ public class SimpleRouletteWheelSelector implements Selector {
         double totalFitness = cumulativeFitness[populationSize-1];
 
         if (totalFitness == 0.0) {
-            throw new RuntimeException("Population crashed! No viable children.");
+//            throw new RuntimeException("Population crashed! No viable children.");
+//Abbas 2017.07.13: The above line causes program to mysteriously crash when initating the population with sequences from a fasta file. I replace the Exception with a warning
+	    System.out.println("Population crashed! No viable children.");
         }
 
         for (int i = 0; i < populationSize; i++) {


### PR DESCRIPTION
When initiatiang the populaiton with sequences from a fasta file, the totalFitness for the first generation is set to zero and the exception for checking if the total fitness of population is non-zero, causes the program to terminate. I replaces the Exception with a warning as a temporary fix.